### PR TITLE
Fix user listing syntax

### DIFF
--- a/conf/user_list.py
+++ b/conf/user_list.py
@@ -1,3 +1,3 @@
 import sys, json
 userlist=json.loads(sys.stdin.readlines()[0])["users"]
-print "{0}".format("\n".join(i["username"] for i in userlist))
+print "{0}".format("\n".join(i["username"] for i in userlist.values()))


### PR DESCRIPTION
Fix the error (https://github.com/julienmalik/shaarli_ynh/issues/7):
> TypeError: string indices must be integers
Caused by `print "{0}".format("\n".join(i["username"] for i in userlist))`
`userlist` is a dictionary with {account :{dictionary of parameters}} so I use values() to return the dictionary of parameters.